### PR TITLE
Don't explode when jar/war isn't available

### DIFF
--- a/src/adzerk/boot_beanstalk.clj
+++ b/src/adzerk/boot_beanstalk.clj
@@ -60,7 +60,8 @@
     (let [p @pod]
       (boot/with-pre-wrap fileset
         (let [[file-path] (boot/by-name [(or file "project.war")] (boot/output-files fileset))
-              file (.getAbsolutePath (boot/tmp-file file-path))]
+              file (when file-path
+                     (.getAbsolutePath (boot/tmp-file file-path)))]
           (pod/with-call-in p
             (adzerk.boot-beanstalk.impl/beanstalk ~(assoc *opts* :file file))))
         fileset))))


### PR DESCRIPTION
This is necessary so that subcommands like `info` work without building.
