### PR TITLE
Bypass resolution of file when :file is not in output-files

### DIFF
--- a/src/adzerk/boot_beanstalk.clj
+++ b/src/adzerk/boot_beanstalk.clj
@@ -61,7 +61,7 @@
     (let [p @pod]
       (boot/with-pre-wrap fileset
         (let [[file-path] (boot/by-name [(or file "project.war")] (boot/output-files fileset))
-              file (.getAbsolutePath (boot/tmp-file file-path))]
+              file (when file-path (.getAbsolutePath (boot/tmp-file file-path)))]
           (pod/with-call-in p
             (adzerk.boot-beanstalk.impl/beanstalk ~(assoc *opts* :file file))))
         fileset))))


### PR DESCRIPTION
This should resolve issue #5 by allowing commands like info, list-stacks to complete. A consequence of this is that failure to specify a file will now be pushed down to the underlying functions that require its presence e.g. https://github.com/adzerk-oss/boot-beanstalk/blob/master/src/adzerk/boot_beanstalk/impl.clj#L33-L34.